### PR TITLE
fix modal hit testing during warped reveal

### DIFF
--- a/components/modules/cmodal.ts
+++ b/components/modules/cmodal.ts
@@ -11,7 +11,7 @@ import { CYBER_DIR, SCREEN_WIDTH, SCREEN_HEIGHT } from "../../env.ts"
 import { Anchor } from "./widget.ts"
 import {
     Cairo, TITLE, MONO, ICONF, ch, CYAN, ACC, HEADER,
-    makeModalPlane, drawGlass, txt, pango, pip, projQuad, segParam, warpReveal, setTxtFX,
+    makeModalPlane, drawGlass, txt, pango, warpReveal, unwarpRevealPoint, setTxtFX,
 } from "./glass.ts"
 import { openWheel, updateWheel, closeWheel, isWheelOpen } from "./appsmenu.ts"
 import { makePlane } from "./proj.ts"
@@ -154,7 +154,7 @@ export const createModal = (spec) => {
     let hitRegions: any[] = [], drag: any = null, hoverKey: any = null, pressKey: any = null, dragKey: any = null, lastXY: any = null
     const ctrl: any = { name }
 
-    const push: any = (reg) => { reg.quad = projQuad(plane, reg.bx0, reg.by0, reg.bx1, reg.by1); hitRegions.push(reg) }
+    const push: any = (reg) => { hitRegions.push(reg) }
     push.hoverKey = null
     push.pressKey = null
     push.dragKey = null
@@ -231,14 +231,21 @@ export const createModal = (spec) => {
     try { evt.add_events(Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.BUTTON_RELEASE_MASK | Gdk.EventMask.POINTER_MOTION_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK | Gdk.EventMask.SCROLL_MASK | Gdk.EventMask.SMOOTH_SCROLL_MASK) } catch {}
     const wbtn = (e) => { try { return e.get_button?.()[1] ?? e.button } catch { return 1 } }
     const xy = (e) => { try { const c = e.get_coords?.(); if (c && c.length >= 3) return [c[1], c[2]] } catch {} try { const x = e.x, y = e.y; if (x != null && y != null) return [x, y] } catch {} return [0, 0] }
+    const localPoint = (e) => { const [x, y] = xy(e); return unwarpRevealPoint(x, y, plane, W, H, intro, seed) }
+    const contains = (r, x, y) => x >= Math.min(r.bx0, r.bx1) && x <= Math.max(r.bx0, r.bx1) && y >= Math.min(r.by0, r.by1) && y <= Math.max(r.by0, r.by1)
+    const sliderParam = (r, x, y) => {
+        const dx = r.u1 - r.u0, dy = r.v1 - r.v0, len2 = dx * dx + dy * dy || 1
+        return Math.max(0, Math.min(1, ((x - r.u0) * dx + (y - r.v0) * dy) / len2))
+    }
     evt.connect("button-press-event", (_w, e) => {
         if (!visible) return true
-        const [x, y] = xy(e); const b = wbtn(e)
+        const point = localPoint(e); if (!point) return false
+        const [x, y] = point; const b = wbtn(e)
         let hit = false
         for (const r of hitRegions) {
-            if (pip(x, y, r.quad)) {
+            if (contains(r, x, y)) {
                 hit = true
-                if (r.kind === "sld") { drag = r; dragKey = r.key; r.on(segParam(plane, r.u0, r.v0, r.u1, r.v1, x, y)); area.queue_draw() }
+                if (r.kind === "sld") { drag = r; dragKey = r.key; r.on(sliderParam(r, x, y)); area.queue_draw() }
                 else if (b === 3 && r.onRight) r.onRight()
                 else if (r.on) { if (r.key) { pressKey = r.key; area.queue_draw() }; r.on() }
                 break
@@ -248,11 +255,13 @@ export const createModal = (spec) => {
     })
     evt.connect("motion-notify-event", (_w, e) => {
         if (!visible) return false
-        const [x, y] = xy(e)
+        const point = localPoint(e)
+        if (!point) { if (hoverKey !== null) { hoverKey = null; area.queue_draw() }; return false }
+        const [x, y] = point
         lastXY = [x, y]
-        if (drag) { drag.on(segParam(plane, drag.u0, drag.v0, drag.u1, drag.v1, x, y)); area.queue_draw(); return false }
+        if (drag) { drag.on(sliderParam(drag, x, y)); area.queue_draw(); return false }
         let nk: any = null
-        for (const r of hitRegions) { if (r.hoverable && pip(x, y, r.quad)) { nk = r.key; break } }
+        for (const r of hitRegions) { if (r.hoverable && contains(r, x, y)) { nk = r.key; break } }
         if (nk !== hoverKey) { hoverKey = nk; area.queue_draw() }
         return false
     })
@@ -606,7 +615,7 @@ const VolCtrl = () => {
             if (!xy) return
             const [x, y] = xy
             for (const r of ctrl.hitRegions()) {
-                if (r.scrollFn && r.kind === "sld" && pip(x, y, r.quad)) {
+                if (r.scrollFn && r.kind === "sld" && x >= Math.min(r.bx0, r.bx1) && x <= Math.max(r.bx0, r.bx1) && y >= Math.min(r.by0, r.by1) && y <= Math.max(r.by0, r.by1)) {
                     const cur = r.curVal ?? 0
                     const nv = Math.max(0, Math.min(1.5, cur + dir * (r.scrollStep || 0.05)))
                     r.scrollFn(nv)

--- a/components/modules/glass.ts
+++ b/components/modules/glass.ts
@@ -108,31 +108,71 @@ export const segParam = (plane: Plane, u0, v0, u1, v1, px, py) => {
 
 
 
-export const warpReveal = (screenCtx, surf, plane: Plane, PW, PH, intro, seed, ss = 1) => {
-
+const REVEAL_BANDS = 9
+const REVEAL_SLICES = 400
+const revealState = (intro, seed, PH) => {
     const e = intro, full = e >= 0.999
     const ease = full ? 1 : e * e * (3 - 2 * e)
     const dec = full ? 0 : 1 - ease
     const slideX = full ? 0 : -26 * dec
-    const N = 400
-    for (let i = 0; i < N; i++) {
-        const v0 = i * PH / N, v1 = (i + 1) * PH / N
-        const dx = slideX
-        const tl = plane.project(0, v0), tr = plane.project(PW, v0), bl = plane.project(0, v1)
-        const br = plane.project(PW, v1)
-        const ulen0 = Math.hypot(tr[0] - tl[0], tr[1] - tl[1])
-        const ulen1 = Math.hypot(br[0] - bl[0], br[1] - bl[1])
-        const ulen = Math.max(ulen0, ulen1)
-        const vlen = Math.hypot(bl[0] - tl[0], bl[1] - tl[1])
-        const ang = Math.atan2(tr[1] - tl[1], tr[0] - tl[0])
-        const sy = vlen / (v1 - v0)
-        const bleed = 1.5 / Math.max(0.0001, sy)
+    const s = Math.floor(seed * 55)
+    const nz = (k) => { const x = Math.sin(s * 12.9 + k * 78.2) * 43758.5; return x - Math.floor(x) }
+    const shiftAt = (v) => full ? 0 : (nz(Math.floor(v / (PH / REVEAL_BANDS)) + 1) * 2 - 1) * 50 * dec * dec
+    return { full, dec, slideX, shiftAt }
+}
+const revealSlice = (plane: Plane, PW, PH, state, i) => {
+    const v0 = i * PH / REVEAL_SLICES, v1 = (i + 1) * PH / REVEAL_SLICES
+    const tl = plane.project(0, v0), tr = plane.project(PW, v0), bl = plane.project(0, v1), br = plane.project(PW, v1)
+    const ulen = Math.max(Math.hypot(tr[0] - tl[0], tr[1] - tl[1]), Math.hypot(br[0] - bl[0], br[1] - bl[1]))
+    const vlen = Math.hypot(bl[0] - tl[0], bl[1] - tl[1])
+    const angle = Math.atan2(tr[1] - tl[1], tr[0] - tl[0])
+    const sy = vlen / (v1 - v0)
+    return {
+        v0, v1,
+        x: tl[0] + state.slideX + state.shiftAt(v0), y: tl[1],
+        angle, cos: Math.cos(angle), sin: Math.sin(angle),
+        sx: ulen / PW, sy, bleed: 1.5 / Math.max(0.0001, sy),
+    }
+}
+
+export const unwarpRevealPoint = (px, py, plane: Plane, PW, PH, intro, seed): [number, number] | null => {
+    const state = revealState(intro, seed, PH)
+    for (let i = REVEAL_SLICES - 1; i >= 0; i--) {
+        const b = revealSlice(plane, PW, PH, state, i)
+        const dx = px - b.x, dy = py - b.y
+        const u = (dx * b.cos + dy * b.sin) / b.sx
+        const lv = (-dx * b.sin + dy * b.cos) / b.sy
+        if (u >= 0 && u <= PW && lv >= -0.4 && lv <= b.v1 - b.v0 + 0.4 + b.bleed)
+            return [u, Math.max(0, Math.min(PH, b.v0 + lv))]
+    }
+    return null
+}
+
+export const warpReveal = (screenCtx, surf, plane: Plane, PW, PH, intro, seed, ss = 1) => {
+    const state = revealState(intro, seed, PH)
+    for (let i = 0; i < REVEAL_SLICES; i++) {
+        const b = revealSlice(plane, PW, PH, state, i)
+        const { v0, v1 } = b
         screenCtx.save()
-        screenCtx.translate(tl[0] + dx, tl[1]); screenCtx.rotate(ang); screenCtx.scale(ulen / PW, sy)
-        screenCtx.rectangle(0, -0.4, PW, (v1 - v0) + 0.4 + bleed); screenCtx.clip()
+        screenCtx.translate(b.x, b.y); screenCtx.rotate(b.angle); screenCtx.scale(b.sx, b.sy)
+        screenCtx.rectangle(0, -0.4, PW, (v1 - v0) + 0.4 + b.bleed); screenCtx.clip()
         if (ss !== 1) screenCtx.scale(1 / ss, 1 / ss)
         screenCtx.setSourceSurface(surf, 0, -v0 * ss); screenCtx.paint()
         screenCtx.restore()
     }
+    if (!state.full) {
+        const { dec, slideX } = state
+        screenCtx.setOperator(12); screenCtx.setLineJoin(0)
+        for (let b = 1; b < REVEAL_BANDS; b++) {
+            const v = b * PH / REVEAL_BANDS, off = 3 + dec * 6, a = dec * 0.6
+            const l = plane.project(14, v), rp = plane.project(PW - 14, v)
+            screenCtx.setLineWidth(1.6)
+            screenCtx.setSourceRGBA(1, 0.13, 0.24, a); screenCtx.newPath(); screenCtx.moveTo(l[0] - off, l[1]); screenCtx.lineTo(rp[0] - off, rp[1]); screenCtx.stroke()
+            screenCtx.setSourceRGBA(0.2, 1, 1, a); screenCtx.newPath(); screenCtx.moveTo(l[0] + off, l[1]); screenCtx.lineTo(rp[0] + off, rp[1]); screenCtx.stroke()
+        }
+        const a0 = plane.project(14, 0), a1 = plane.project(14, PH)
+        screenCtx.setSourceRGBA(0.85, 0.98, 1, dec * 0.85); screenCtx.setLineWidth(2.4)
+        screenCtx.newPath(); screenCtx.moveTo(a0[0] + slideX, a0[1]); screenCtx.lineTo(a1[0] + slideX, a1[1]); screenCtx.stroke()
+        screenCtx.setOperator(2)
+    }
 }
-


### PR DESCRIPTION
hitboxes were off in popups like the weather, which were "leaning" (i.e. warped). I think there's probably a more elegant way to handle this, but this works for me