### PR TITLE
feat: robust app launching, aurbar toggle, float→int rounding

### DIFF
--- a/components/modules/appsmenu.ts
+++ b/components/modules/appsmenu.ts
@@ -4,6 +4,7 @@ import { interval, timeout, execAsync } from "astal"
 import Gdk from "gi://Gdk?version=3.0"
 import Gtk from "gi://Gtk?version=3.0"
 import Gio from "gi://Gio"
+import GLib from "gi://GLib"
 import { SCREEN_WIDTH, SCREEN_HEIGHT, CYBER_DIR } from "../../env.ts"
 import { NEON, USER, USER_A, f, onColorChange, menuBg, glassMode } from "./colors.ts"
 import { sndOn, sndFile, animOn } from "./config.ts"
@@ -315,11 +316,41 @@ export const closeWheel = () => {
   active = false; introTarget = 0; animate()
   const r = wheelCfg.onReset; if (r) r()
 }
+const LAUNCH_HELPER = `${GLib.get_home_dir()}/.local/bin/cyberarch-launch-desktop`
+const ensureSessionEnv = () => {
+  const rt = GLib.getenv("XDG_RUNTIME_DIR") || `/run/user/${GLib.get_user_name() === "root" ? 0 : 1000}`
+  if (!GLib.getenv("XDG_RUNTIME_DIR")) GLib.setenv("XDG_RUNTIME_DIR", rt, true)
+  if (!GLib.getenv("DBUS_SESSION_BUS_ADDRESS")) GLib.setenv("DBUS_SESSION_BUS_ADDRESS", `unix:path=${rt}/bus`, true)
+  if (!GLib.getenv("XDG_SESSION_TYPE")) GLib.setenv("XDG_SESSION_TYPE", "wayland", true)
+  if (!GLib.getenv("XDG_CURRENT_DESKTOP")) GLib.setenv("XDG_CURRENT_DESKTOP", "Hyprland", true)
+  if (!GLib.getenv("XDG_SESSION_DESKTOP")) GLib.setenv("XDG_SESSION_DESKTOP", "Hyprland", true)
+  if (!GLib.getenv("DISPLAY")) GLib.setenv("DISPLAY", ":0", true)
+}
+const launchAppRobust = (a) => {
+  ensureSessionEnv()
+  const name = (() => { try { return a.get_name?.() || "unknown" } catch { return "unknown" } })()
+  const id = (() => { try { return a.get_id?.() || "" } catch { return "" } })()
+  const file = (() => { try { return a.get_filename?.() || "" } catch { return "" } })()
+  print(`[apps] ACTIVATE name=${name} id=${id} file=${file}`)
+  if (file) {
+    execAsync([LAUNCH_HELPER, file, id, name]).catch((e) => print("[apps] desktop helper error:", e))
+    return
+  }
+  try {
+    const ctx = new Gio.AppLaunchContext()
+    ctx.setenv("DBUS_SESSION_BUS_ADDRESS", GLib.getenv("DBUS_SESSION_BUS_ADDRESS") || "")
+    ctx.setenv("XDG_SESSION_TYPE", "wayland")
+    ctx.setenv("XDG_CURRENT_DESKTOP", "Hyprland")
+    const ok = a.launch([], ctx)
+    print(`[apps] Gio launch result=${ok}`)
+  } catch (e) { print("[apps] Gio launch error:", e) }
+}
+
 export const openAppsMenu = () => {
  if (!menuWin) return
  if (active) { closeWheel(); return }
  appInfoCache = null
- openWheel({ title: "APPS", subtitle: "// CYBERDECK.OS — RUNNING", footer: FOOTER_APPS, searchable: true, onActivate: (a) => { try { a.launch([], null) } catch (e) { print("[apps] launch:", e) } closeWheel() }, onSecondary: null, onReset: null, emptyText: "// NO APPS" }, buildAppEntries())
+ openWheel({ title: "APPS", subtitle: "// CYBERDECK.OS — RUNNING", footer: FOOTER_APPS, searchable: true, keymode: Keymode.EXCLUSIVE, onActivate: (a) => { launchAppRobust(a); closeWheel() }, onSecondary: null, onReset: null, emptyText: "// NO APPS" }, buildAppEntries())
 }
 
 export const AppsMenuWindow = () => {
@@ -334,7 +365,23 @@ export const AppsMenuWindow = () => {
  evt.connect("button-press-event", (_w, e) => {
      if (!active) return true
      let b = 1; try { b = e.get_button?.()[1] ?? e.button } catch {}
-     const r = rowAtY(mouseY)
+     // Use the click event's coordinates directly. The previous code relied on
+     // a cached motion-notify Y position, which can be stale after wheel/touchpad scroll.
+     let clickY = mouseY
+     try {
+         const c = e.get_coords?.()
+         if (c && c.length >= 3 && c[0]) clickY = c[2]
+         else if (typeof e.y === "number") clickY = e.y
+     } catch { if (typeof e.y === "number") clickY = e.y }
+     mouseY = clickY
+     let r = rowAtY(clickY)
+    if (!r && RENDER.length) {
+      r = RENDER.reduce((best, cur) => {
+        const by = (best.y0 + best.y1) / 2, cy = (cur.y0 + cur.y1) / 2
+        return Math.abs(cy - clickY) < Math.abs(by - clickY) ? cur : best
+      }, RENDER[0])
+    }
+    print(`[apps] CLICK y=${clickY} row=${r ? r.entry?.label : "none"}`)
      if (b === 3) { if (r && wheelCfg.onSecondary) wheelCfg.onSecondary(r.entry.data); else closeWheel(); return true }
      if (r) {
          if (typeof r.idxAbs === "number" && r.idxAbs !== Math.round(scroll)) {
@@ -373,7 +420,10 @@ export const AppsMenuWindow = () => {
      if (k === Gdk.KEY_Escape) { if (query) { query = ""; applyFilter() } else closeWheel(); return true }
       if (k === Gdk.KEY_Up) { scrollTarget -= 1; const n = filtered.length; if (n <= VISIBLE) scrollTarget = Math.max(0, scrollTarget); beep(); animate(); return true }
       if (k === Gdk.KEY_Down) { scrollTarget += 1; const n = filtered.length; if (n <= VISIBLE) scrollTarget = Math.min(n - 1, scrollTarget); beep(); animate(); return true }
-     if (k === Gdk.KEY_Return || k === Gdk.KEY_KP_Enter) { if (n) activate(filtered[mod(Math.round(scroll), n)]); return true }
+     if (k === Gdk.KEY_Return || k === Gdk.KEY_KP_Enter) {
+       if (n) { const e = filtered[mod(Math.round(scroll), n)]; print(`[apps] ENTER row=${e?.label || "unknown"}`); activate(e) }
+       return true
+     }
      if (k === Gdk.KEY_BackSpace) { if (wheelCfg.searchable && query) { query = query.slice(0, -1); applyFilter() } return true }
 
      const uni = Gdk.keyval_to_unicode(k)

--- a/core.ts
+++ b/core.ts
@@ -45,6 +45,7 @@ import { NowPlayingWindow } from "./components/modules/nowplaying.ts"
 
 const SCSS = `${COMPONENTS_DIR}/style/cyber.scss`
 const CSS = `${COMPONENTS_DIR}/style/cyber.css`
+const AURBAR_DISABLED = GLib.file_test(`${GLib.get_home_dir()}/.config/cyberarch/disable-aurbar`, GLib.FileTest.EXISTS)
 
 const compileCss = async () => {
  try {
@@ -320,7 +321,7 @@ App.start({
  }
  passthrough(OsdWindow())
  passthrough(NotifPopupWindow())
- passthrough(AurBarWindow())
+ if (!AURBAR_DISABLED) passthrough(AurBarWindow())
  NotifHudWindow()
  NowPlayingWindow()
  WsAnimWindow()

--- a/theme.lua
+++ b/theme.lua
@@ -8,8 +8,8 @@ end
 
 hl.exec_cmd("dbus-update-activation-environment --systemd --all")
 hl.exec_cmd("sh -c 'sleep 3; hyprctl dispatch exec \"dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XAUTHORITY XCURSOR_THEME XCURSOR_SIZE\"' &")
-hl.exec_cmd("killall -9 waybar mako dunst swaync 2>/dev/null; systemctl --user stop waybar mako dunst swaync 2>/dev/null || true")
-hl.exec_cmd("sh -c 'pgrep -x gjs >/dev/null 2>&1 || { " .. os.getenv("HOME") .. "/.local/bin/ags quit -i cyberpunk 2>/dev/null; sleep 1; " .. cyberpunk .. "/scripts/launch-theme; }'")
+hl.exec_cmd("killall -9 mako dunst swaync 2>/dev/null; systemctl --user stop mako dunst swaync 2>/dev/null || true")
+hl.exec_cmd("sh -c '" .. os.getenv("HOME") .. "/.local/bin/ags list 2>/dev/null | grep -qx cyberpunk || { " .. os.getenv("HOME") .. "/.local/bin/ags quit -i cyberpunk 2>/dev/null; sleep 1; " .. cyberpunk .. "/scripts/launch-theme; }'")
 hl.exec_cmd(cyberpunk .. "/scripts/ws pin")
 local user_dir = (os.getenv("XDG_CONFIG_HOME") or (os.getenv("HOME") .. "/.config")) .. "/cyberarch"
 local ucfg = {}
@@ -79,14 +79,14 @@ if wmf then
 end
 local shadow_color = nil
 local border_override = nil
-if wmt.wmBorderSize and type(wm.wmBorderSize) == "number" then border_size = wm.wmBorderSize end
+if wmt.wmBorderSize and type(wm.wmBorderSize) == "number" then border_size = math.floor(wm.wmBorderSize + 0.5) end
 if wmt.wmBorders and wm.wmBorders == false then border_size = 0 end
 if type(wm.wmBorderColor) == "string" then border_override = h2rgb(wm.wmBorderColor) end
 if type(wm.wmShadowColor) == "string" and wm.wmShadowColor ~= "" then shadow_color = h2rgb(wm.wmShadowColor) end
 if wmt.wmGlow ~= nil then glow = wm.wmGlow == true end
-if wmt.wmGlowRange and type(wm.wmGlowRange) == "number" then glow_range = wm.wmGlowRange end
-if wmt.wmGlowRp and type(wm.wmGlowRp) == "number" then glow_rp = wm.wmGlowRp end
-if wmt.wmRounding and type(wm.wmRounding) == "number" then rounding = wm.wmRounding end
+if wmt.wmGlowRange and type(wm.wmGlowRange) == "number" then glow_range = math.floor(wm.wmGlowRange + 0.5) end
+if wmt.wmGlowRp and type(wm.wmGlowRp) == "number" then glow_rp = math.floor(wm.wmGlowRp + 0.5) end
+if wmt.wmRounding and type(wm.wmRounding) == "number" then rounding = math.floor(wm.wmRounding + 0.5) end
 local corner_mode = type(wm.wmCorners) == "string" and wm.wmCorners or "round"
 local corner_touched = wmt.wmRoundingTl or wmt.wmRoundingTr or wmt.wmRoundingBl or wmt.wmRoundingBr
 if wmt.wmCorners then
@@ -111,7 +111,7 @@ if rounding > 40 then rounding = 40 end
 local shadow_on = true
 if wmt.wmShadow ~= nil then shadow_on = wm.wmShadow == true end
 local shadow_range = glow_range
-if wmt.wmShadowRange and type(wm.wmShadowRange) == "number" then shadow_range = wm.wmShadowRange end
+if wmt.wmShadowRange and type(wm.wmShadowRange) == "number" then shadow_range = math.floor(wm.wmShadowRange + 0.5) end
 local shadow_alpha = glow_alpha
 if wmt.wmShadowAlpha and type(wm.wmShadowAlpha) == "number" then
     shadow_alpha = string.format("%02x", math.floor(wm.wmShadowAlpha * 2.55 + 0.5))


### PR DESCRIPTION
## Summary

### `appsmenu.ts` — Robust app activation & click fix
- **Session environment:** `ensureSessionEnv()` sets XDG_RUNTIME_DIR, DBUS_SESSION_BUS_ADDRESS, XDG_SESSION_TYPE, XDG_CURRENT_DESKTOP, XDG_SESSION_DESKTOP, DISPLAY before every launch.
- **New `launchAppRobust()`:** tries the `cyberarch-launch-desktop` helper script first; falls back to `Gio.AppLaunchContext` for desktop-file IDs. Adds debug prints for traceability.
- **Click Y-coordinate:** reads coordinates directly from `button-press-event` via `e.get_coords()` instead of relying on a stale motion-notify cache. Falls back to closest rendered row when the click lands between items.

### `theme.lua` — Float precision fix & startup cleanup
- Cast `border_size`, `glow_range`, `glow_rp`, `rounding`, `shadow_range` to integers via `math.floor(x + 0.5)` for cleaner wibox painting.
- Removed waybar from the AGS startup kill-list (no longer managed here). Added a guard so `launch-theme` only runs if cyberpunk isn't already running (`ags list | grep -qx cyberpunk`).

### `core.ts` — Conditional AurBar
- New toggle file `~/.config/cyberarch/disable-aurbar`. If present, the aurora bar is skipped at startup.

### Checklist
- [ ] Tested app launch from wheel on Hyprland/XDG session