### PR TITLE
feat: improve Netwatch login and installer safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,26 @@ chmod +x install.sh
 
 The installer will download any required dependencies, install the theme, quickshell and the necessary packages, along with optional features such as fish, GPU Terminals in theme style, and wallpapers. 
 
+### Safe preflight and recovery
+
+Inspect missing dependencies without requesting root access, refreshing package databases, or changing the system:
+
+```bash
+./install.sh --dry-run
+```
+
+If installation stops, do not bypass its runtime checks. Save the complete terminal output, fix the reported dependency, and run the dry-run again before retrying. For graphics failures, check `vulkaninfo --summary` and `rio --version`. For login failures, inspect `journalctl -b -u sddm --no-pager` from a TTY or another working desktop session.
+
+The installer deploys the Netwatch theme before selecting it and preserves an existing SDDM configuration at `/etc/sddm.conf.pre-cyberarch`. Restore it only when that backup exists:
+
+```bash
+sudo cp -a /etc/sddm.conf.pre-cyberarch /etc/sddm.conf
+```
+
+If switching display managers fails, the installer restores that configuration backup and re-enables the previously active display manager before stopping.
+
+When another display manager is active, answer `N` at the greeter replacement prompt to leave it, SDDM, PAM, and the Hyprland lock command unchanged.
+
 ---
 
 ## ⌁ Updating
@@ -253,7 +273,10 @@ cyberpunk/
 │
 ├─ components/
 │  ├─ modules/          # The widgets and main components of the theme HD
-│  ├─ login/            # Quickshell login
+│  ├─ login/
+│  │  ├─ lock_shell.qml       # Quickshell session-lock entry point
+│  │  ├─ themes/netwatch/     # Netwatch Quickshell lock theme
+│  │  └─ sddm-theme/          # Netwatch SDDM greeter theme
 │  ├─ style/            # cyber.scss and cyber.css
 │  └─ glitch.frag
 │
@@ -261,6 +284,15 @@ cyberpunk/
 ├─ assets/               # fonts, cursor, icons, kitty, kvantum, hyprbars, and resources
 └─ preview/
 ```
+
+### Login theme architecture
+
+The two Netwatch directories target different runtimes and are not interchangeable:
+
+- `components/login/themes/netwatch/` is loaded by `lock_shell.qml` inside the user's running Hyprland session. It uses Quickshell's session-lock integration.
+- `components/login/sddm-theme/` is copied to `/usr/share/sddm/themes/netwatch/` and loaded by SDDM before a desktop session starts. SDDM-only models such as `userModel` and `sessionModel` belong here.
+
+Keep runtime-specific behavior in its corresponding directory. When a visual change should appear in both screens, port it deliberately and test both runtimes rather than copying one `Main.qml` over the other.
 
 ## TODO List
 
@@ -307,4 +339,3 @@ suggestions are welcome! :)
 
 
 </div>
-

--- a/components/login/sddm-theme/Main.qml
+++ b/components/login/sddm-theme/Main.qml
@@ -158,8 +158,9 @@ Rectangle {
 
     function doAuth() {
         if (root.lockUser === "" || root.lockInput === "" || root.isAuthenticating) return
+        sessionSelector.closeMenu()
         root.isAuthenticating = true
-        sddm.login(root.lockUser, root.lockInput, sessionModel.lastIndex)
+        sddm.login(root.lockUser, root.lockInput, sessionSelector.currentIndex)
     }
 
     Connections {
@@ -185,7 +186,7 @@ Rectangle {
         root.dateStr = "2077."+p(d.getMonth()+1)+"."+p(d.getDate())+"  "+day[d.getDay()]
     }}
 
-    MouseArea { anchors.fill: parent; cursorShape: Qt.ArrowCursor; z: -1 }
+    MouseArea { anchors.fill: parent; cursorShape: Qt.ArrowCursor; z: -1; onPressed: sessionSelector.closeMenu() }
 
     Loader { anchors.fill: parent; source: "Background.qml" }
 
@@ -287,9 +288,31 @@ Rectangle {
                         onTextEdited: root.lockUser = text
                         Keys.onReturnPressed: pwd.forceActiveFocus()
                         Keys.onEnterPressed: pwd.forceActiveFocus()
-                        Keys.onTabPressed: pwd.forceActiveFocus()
+                        Keys.onTabPressed: sessionSelector.interactive ? sessionSelector.forceActiveFocus() : pwd.forceActiveFocus()
                         Keys.onBacktabPressed: pwd.forceActiveFocus() } }
-                MouseArea { anchors.fill: parent; cursorShape: Qt.IBeamCursor; onClicked: user.forceActiveFocus() }
+                MouseArea { anchors.fill: parent; cursorShape: Qt.IBeamCursor; onClicked: {
+                    sessionSelector.closeMenu(); user.forceActiveFocus()
+                } }
+            }
+            Item { width: 1; height: 10 * s }
+
+            SessionSelector {
+                id: sessionSelector
+                width: parent.width
+                model: sessionModel
+                rememberedIndex: sessionModel.lastIndex
+                scaleFactor: root.s
+                accentColor: root.cAmber
+                accentSoftColor: root.cAmberSoft
+                textColor: root.cWhite
+                mutedColor: root.cGrayDim
+                labelColor: root.cYellow
+                backgroundColor: root.cBlack
+                lineColor: root.cLineDim
+                labelFontFamily: fExo.name
+                valueFontFamily: fMono.name
+                previousFocusItem: user
+                nextFocusItem: pwd
             }
             Item { width: 1; height: 10 * s }
 
@@ -321,8 +344,10 @@ Rectangle {
                         Keys.onEnterPressed: root.doAuth()
                         Keys.onEscapePressed: root.lockInput = ""
                         Keys.onTabPressed: user.forceActiveFocus()
-                        Keys.onBacktabPressed: user.forceActiveFocus() } }
-                MouseArea { anchors.fill: parent; cursorShape: Qt.IBeamCursor; onClicked: pwd.forceActiveFocus() }
+                        Keys.onBacktabPressed: sessionSelector.interactive ? sessionSelector.forceActiveFocus() : user.forceActiveFocus() } }
+                MouseArea { anchors.fill: parent; cursorShape: Qt.IBeamCursor; onClicked: {
+                    sessionSelector.closeMenu(); pwd.forceActiveFocus()
+                } }
             }
             Item { width: 1; height: 10 * s }
 
@@ -380,5 +405,5 @@ Rectangle {
         NumberAnimation{target:panelContainer;property:"anchors.horizontalCenterOffset";to:0;duration:45} }
 
     Timer { id: focusRetry; interval: 60; repeat: true; property int cnt: 0
-        onTriggered: { if (!user.activeFocus && !pwd.activeFocus) user.forceActiveFocus(); if(++cnt>=6){running=false;cnt=0} } }
+        onTriggered: { if (!user.activeFocus && !pwd.activeFocus && !sessionSelector.activeFocus) user.forceActiveFocus(); if(++cnt>=6){running=false;cnt=0} } }
 }

--- a/components/login/sddm-theme/SessionOption.qml
+++ b/components/login/sddm-theme/SessionOption.qml
@@ -1,0 +1,59 @@
+import QtQuick
+
+Item {
+    id: option
+
+    required property string name
+    required property int index
+    property bool highlighted: false
+    property real scaleFactor: 1
+    property color accentColor: "#FF2A3C"
+    property color textColor: "#E6E4D8"
+    property color backgroundColor: "#0A0A08"
+    property string fontFamily: ""
+
+    signal highlightRequested(int index)
+    signal selected(int index)
+
+    objectName: "sessionOption" + index
+    height: 34 * scaleFactor
+
+    Rectangle {
+        anchors.fill: parent
+        color: option.highlighted || optionMouse.containsMouse ? option.accentColor : "transparent"
+        opacity: option.highlighted || optionMouse.containsMouse ? 0.9 : 1
+    }
+
+    Text {
+        anchors.left: parent.left
+        anchors.leftMargin: 12 * option.scaleFactor
+        anchors.verticalCenter: parent.verticalCenter
+        text: ">"
+        font.family: option.fontFamily
+        font.pixelSize: 12 * option.scaleFactor
+        color: option.highlighted || optionMouse.containsMouse ? option.backgroundColor : option.accentColor
+    }
+
+    Text {
+        anchors.left: parent.left
+        anchors.leftMargin: 34 * option.scaleFactor
+        anchors.right: parent.right
+        anchors.rightMargin: 12 * option.scaleFactor
+        anchors.verticalCenter: parent.verticalCenter
+        text: option.name.toUpperCase()
+        elide: Text.ElideRight
+        font.family: option.fontFamily
+        font.pixelSize: 11 * option.scaleFactor
+        font.letterSpacing: 0.8 * option.scaleFactor
+        color: option.highlighted || optionMouse.containsMouse ? option.backgroundColor : option.textColor
+    }
+
+    MouseArea {
+        id: optionMouse
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        onEntered: option.highlightRequested(option.index)
+        onClicked: option.selected(option.index)
+    }
+}

--- a/components/login/sddm-theme/SessionSelector.qml
+++ b/components/login/sddm-theme/SessionSelector.qml
@@ -1,0 +1,240 @@
+import QtQuick
+
+Item {
+    id: selector
+
+    property var model
+    property int rememberedIndex: -1
+    property int currentIndex: 0
+    property int highlightedIndex: currentIndex
+    property bool expanded: false
+    property bool selectionInitialized: false
+
+    property real scaleFactor: 1
+    property color accentColor: "#FF2A3C"
+    property color accentSoftColor: "#FF6B78"
+    property color textColor: "#E6E4D8"
+    property color mutedColor: "#5A4A4E"
+    property color labelColor: "#FFF200"
+    property color backgroundColor: "#0A0A08"
+    property color lineColor: Qt.rgba(154/255, 150/255, 138/255, 0.28)
+    property string labelFontFamily: ""
+    property string valueFontFamily: ""
+    property Item previousFocusItem
+    property Item nextFocusItem
+
+    readonly property int sessionCount: sessionObjects.count
+    readonly property bool interactive: sessionCount > 1
+    readonly property string currentSessionName: {
+        var count = sessionObjects.count
+        var session = count > 0 ? sessionObjects.objectAt(currentIndex) : null
+        return session ? session.sessionName : qsTr("نشستی یافت نشد")
+    }
+
+    height: 42 * scaleFactor
+    activeFocusOnTab: interactive
+    z: expanded ? 20 : 0
+
+    Accessible.role: Accessible.ComboBox
+    Accessible.name: qsTr("انتخاب نشست")
+    Accessible.description: currentSessionName
+    Accessible.focusable: interactive
+
+    function normalizedIndex(index) {
+        if (sessionCount === 0) return 0
+        return index >= 0 && index < sessionCount ? index : 0
+    }
+
+    function syncSelection() {
+        if (!selectionInitialized) {
+            currentIndex = normalizedIndex(rememberedIndex)
+        } else {
+            currentIndex = normalizedIndex(currentIndex)
+        }
+        highlightedIndex = currentIndex
+    }
+
+    function openMenu() {
+        if (!interactive) return
+        highlightedIndex = currentIndex
+        expanded = true
+        sessionList.positionViewAtIndex(highlightedIndex, ListView.Contain)
+    }
+
+    function closeMenu() {
+        expanded = false
+        highlightedIndex = currentIndex
+    }
+
+    function toggleMenu() {
+        if (expanded) closeMenu()
+        else openMenu()
+    }
+
+    function activateHighlightedSession() {
+        if (expanded) selectSession(highlightedIndex)
+        else openMenu()
+    }
+
+    function moveHighlight(offset) {
+        if (!expanded) openMenu()
+        if (!expanded) return
+        highlightedIndex = (highlightedIndex + offset + sessionCount) % sessionCount
+        sessionList.positionViewAtIndex(highlightedIndex, ListView.Contain)
+    }
+
+    function selectSession(index) {
+        if (sessionCount === 0) return
+        currentIndex = normalizedIndex(index)
+        closeMenu()
+        forceActiveFocus()
+    }
+
+    onSessionCountChanged: syncSelection()
+    onRememberedIndexChanged: {
+        if (!selectionInitialized) syncSelection()
+    }
+    Component.onCompleted: {
+        syncSelection()
+        selectionInitialized = true
+    }
+
+    Keys.onReturnPressed: activateHighlightedSession()
+    Keys.onEnterPressed: activateHighlightedSession()
+    Keys.onEscapePressed: closeMenu()
+    Keys.onUpPressed: moveHighlight(-1)
+    Keys.onDownPressed: moveHighlight(1)
+    Keys.onTabPressed: {
+        closeMenu()
+        if (nextFocusItem) nextFocusItem.forceActiveFocus()
+    }
+    Keys.onBacktabPressed: {
+        closeMenu()
+        if (previousFocusItem) previousFocusItem.forceActiveFocus()
+    }
+    Keys.onSpacePressed: activateHighlightedSession()
+
+    Instantiator {
+        id: sessionObjects
+        model: selector.model
+        delegate: QtObject {
+            required property string name
+            readonly property string sessionName: name
+        }
+    }
+
+    CutPanel {
+        anchors.fill: parent
+        strokeColor: selector.activeFocus || selector.expanded ? selector.accentColor : selector.lineColor
+        strokeWidth: 1 * selector.scaleFactor
+        cut: 8 * selector.scaleFactor
+        cutTopRight: true
+        cutBottomLeft: true
+        fillColor: selector.backgroundColor
+        fillOpacity: selectorMouse.containsMouse || selector.expanded ? 0.72 : 0.4
+
+        Behavior on strokeColor { ColorAnimation { duration: 180 } }
+        Behavior on fillOpacity { NumberAnimation { duration: 160 } }
+    }
+
+    Rectangle {
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        width: 2 * selector.scaleFactor
+        color: selector.activeFocus || selector.expanded ? selector.accentColor : selector.lineColor
+        Behavior on color { ColorAnimation { duration: 180 } }
+    }
+
+    Text {
+        anchors.left: parent.left
+        anchors.leftMargin: 14 * selector.scaleFactor
+        anchors.verticalCenter: parent.verticalCenter
+        text: qsTr("نشست")
+        font.family: selector.labelFontFamily
+        font.bold: true
+        font.pixelSize: 9.5 * selector.scaleFactor
+        font.letterSpacing: 1 * selector.scaleFactor
+        color: selector.labelColor
+    }
+
+    Text {
+        anchors.left: parent.left
+        anchors.leftMargin: 78 * selector.scaleFactor
+        anchors.right: sessionArrow.left
+        anchors.rightMargin: 10 * selector.scaleFactor
+        anchors.verticalCenter: parent.verticalCenter
+        text: selector.currentSessionName.toUpperCase()
+        elide: Text.ElideRight
+        font.family: selector.valueFontFamily
+        font.pixelSize: 11 * selector.scaleFactor
+        font.letterSpacing: 0.8 * selector.scaleFactor
+        color: selector.interactive ? selector.accentColor : selector.textColor
+    }
+
+    Text {
+        id: sessionArrow
+        anchors.right: parent.right
+        anchors.rightMargin: 14 * selector.scaleFactor
+        anchors.verticalCenter: parent.verticalCenter
+        text: selector.interactive ? (selector.expanded ? "⌃" : "⌄") : ""
+        font.family: selector.valueFontFamily
+        font.pixelSize: 15 * selector.scaleFactor
+        color: selector.activeFocus || selectorMouse.containsMouse ? selector.accentSoftColor : selector.mutedColor
+    }
+
+    MouseArea {
+        id: selectorMouse
+        anchors.fill: parent
+        enabled: selector.interactive
+        hoverEnabled: true
+        cursorShape: selector.interactive ? Qt.PointingHandCursor : Qt.ArrowCursor
+        onClicked: {
+            selector.forceActiveFocus()
+            selector.toggleMenu()
+        }
+    }
+
+    Item {
+        id: sessionMenu
+        anchors.top: parent.bottom
+        anchors.topMargin: 4 * selector.scaleFactor
+        width: parent.width
+        height: selector.expanded ? Math.min(selector.sessionCount, 4) * 34 * selector.scaleFactor + 4 * selector.scaleFactor : 0
+        visible: height > 0
+        clip: true
+
+        CutPanel {
+            anchors.fill: parent
+            strokeColor: selector.accentColor
+            strokeWidth: 1 * selector.scaleFactor
+            cut: 8 * selector.scaleFactor
+            cutTopLeft: true
+            cutBottomRight: true
+            fillColor: selector.backgroundColor
+            fillOpacity: 0.96
+        }
+
+        ListView {
+            id: sessionList
+            anchors.fill: parent
+            anchors.margins: 2 * selector.scaleFactor
+            clip: true
+            model: selector.model
+            currentIndex: selector.highlightedIndex
+            boundsBehavior: Flickable.StopAtBounds
+
+            delegate: SessionOption {
+                width: sessionList.width
+                scaleFactor: selector.scaleFactor
+                highlighted: index === selector.highlightedIndex
+                accentColor: selector.accentColor
+                textColor: selector.textColor
+                backgroundColor: selector.backgroundColor
+                fontFamily: selector.valueFontFamily
+                onHighlightRequested: index => selector.highlightedIndex = index
+                onSelected: index => selector.selectSession(index)
+            }
+        }
+    }
+}

--- a/install.sh
+++ b/install.sh
@@ -159,6 +159,25 @@ DRYRUN=0
 if [ "${1:-}" = "--dry-run" ] || [ -n "${AUG_DRYRUN:-}" ]; then DRYRUN=1; fi
 [ "$DRYRUN" = 1 ] || sudo_prime
 
+hdr "DEPENDENCY SCAN"
+declare -a miss_repo=() miss_aur=()
+pkg_has() { pacman -Qq "$1" &>/dev/null || pacman -Qg "$1" &>/dev/null; }
+for p in "${REPO[@]}"; do
+  if pkg_has "$p"; then printf "  ${GRN}✓${R} %s\n" "$p"
+  else printf "  ${RED}✗${R} %-22s ${GREY}→ install${R}\n" "$p"; miss_repo+=("$p"); fi
+done
+for p in "${AUR[@]}"; do
+  if pkg_has "$p"; then printf "  ${GRN}✓${R} %s\n" "$p"
+  else printf "  ${RED}✗${R} %-22s ${GREY}→ install (AUR)${R}\n" "$p"; miss_aur+=("$p"); fi
+done
+mapfile -t miss_repo < <(printf '%s\n' "${miss_repo[@]}" | awk 'NF' | sort -u)
+mapfile -t miss_aur  < <(printf '%s\n' "${miss_aur[@]}"  | awk 'NF' | sort -u)
+if [ "${1:-}" = "--dry-run" ] || [ -n "${AUG_DRYRUN:-}" ]; then
+  hdr "DRY RUN |::| no changes will be made"
+  printf "  ${CYAN}repo:${R} %s\n  ${CYAN}aur :${R} %s\n" "${miss_repo[*]:-none}" "${miss_aur[*]:-none}"
+  line; exit 0
+fi
+
 hdr "SYSTEM UPGRADE"
 printf "[!] Run a full system upgrade before installing theme? (y/N) "
 read -r ans </dev/tty
@@ -198,25 +217,6 @@ elif [ -z "$AVAIL" ] || [ "$AVAIL" != "$CUR" ]; then
   fi
 else
   ok "Hyprland $CUR already up to date."
-fi
-
-hdr "DEPENDENCY SCAN"
-declare -a miss_repo=() miss_aur=()
-pkg_has() { pacman -Qq "$1" &>/dev/null || pacman -Qg "$1" &>/dev/null; }
-for p in "${REPO[@]}"; do
-  if pkg_has "$p"; then printf "  ${GRN}✓${R} %s\n" "$p"
-  else printf "  ${RED}✗${R} %-22s ${GREY}→ install${R}\n" "$p"; miss_repo+=("$p"); fi
-done
-for p in "${AUR[@]}"; do
-  if pkg_has "$p"; then printf "  ${GRN}✓${R} %s\n" "$p"
-  else printf "  ${RED}✗${R} %-22s ${GREY}→ install (AUR)${R}\n" "$p"; miss_aur+=("$p"); fi
-done
-mapfile -t miss_repo < <(printf '%s\n' "${miss_repo[@]}" | awk 'NF' | sort -u)
-mapfile -t miss_aur  < <(printf '%s\n' "${miss_aur[@]}"  | awk 'NF' | sort -u)
-if [ "${1:-}" = "--dry-run" ] || [ -n "${AUG_DRYRUN:-}" ]; then
-  hdr "DRY RUN |::| no changes will be made"
-  printf "  ${CYAN}repo:${R} %s\n  ${CYAN}aur :${R} %s\n" "${miss_repo[*]:-none}" "${miss_aur[*]:-none}"
-  line; exit 0
 fi
 
 CANON="$HOME/.config/hypr/themes/cyberpunk"
@@ -416,7 +416,53 @@ fi
 
 if [ "$LOCK_STACK" = 1 ] && command -v sddm >/dev/null 2>&1; then
   ok "sddm installed"
+  SDDM_THEME_DIR="/usr/share/sddm/themes/netwatch"
+  if sudo install -d -m 755 "$SDDM_THEME_DIR" && sudo cp -rf "$LOGINSRC/sddm-theme"/. "$SDDM_THEME_DIR"/; then
+    ok "sddm theme deployed → $SDDM_THEME_DIR"
+  else
+    fatal "the netwatch sddm theme could not be deployed." \
+      "تنظیمات SDDM تغییر نکرد؛ صفحهٔ ورود فعلی همچنان فعال است." \
+      "Deploy it by hand:" \
+      "  sudo install -d -m 755 $SDDM_THEME_DIR" \
+      "  sudo cp -rf '$LOGINSRC/sddm-theme'/. $SDDM_THEME_DIR/"
+  fi
+  if sudo install -d -m 755 -o "$(id -un)" -g "$(id -gn)" "$SDDM_THEME_DIR/current"; then
+    if ! ls "$SDDM_THEME_DIR/current"/image.* >/dev/null 2>&1 && ! ls "$SDDM_THEME_DIR/current"/video.* >/dev/null 2>&1; then
+      SEED_WP=""
+      if [ -r "$USER_DIR/wallpaper.lua" ]; then
+        SEED_WP="$(sed -n 's/^[[:space:]]*wallpaper[[:space:]]*=[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$USER_DIR/wallpaper.lua" | tail -n 1)"
+      fi
+      [ -n "${SEED_WP:-}" ] && [ -r "$SEED_WP" ] || SEED_WP="$WALLPAPERS_PATH/netwatch/lucy.mp4"
+      SEED_EXT="${SEED_WP##*.}"
+      if [ -n "$SEED_EXT" ] && [ "$SEED_EXT" != "$SEED_WP" ] && [ -r "$SEED_WP" ]; then
+        case "$SEED_EXT" in
+          mp4|webm|mkv|mov) cp -f "$SEED_WP" "$SDDM_THEME_DIR/current/video.$SEED_EXT" ;;
+          *) cp -f "$SEED_WP" "$SDDM_THEME_DIR/current/image.$SEED_EXT" ;;
+        esac
+        chmod 644 "$SDDM_THEME_DIR/current"/image.* "$SDDM_THEME_DIR/current"/video.* 2>/dev/null
+        ok "sddm current wallpaper seeded → $SDDM_THEME_DIR/current"
+      else
+        warn "could not seed sddm current wallpaper |::| first theme load will deploy it"
+      fi
+    else
+      ok "sddm current wallpaper kept → $SDDM_THEME_DIR/current"
+    fi
+  else
+    warn "could not create $SDDM_THEME_DIR/current |::| sddm falls back to the theme's bg.mp4"
+  fi
+
   SDDM_CONF="/etc/sddm.conf"
+  SDDM_CONF_BACKUP="/etc/sddm.conf.pre-cyberarch"
+  if [ -f "$SDDM_CONF" ]; then
+    if [ -e "$SDDM_CONF_BACKUP" ]; then
+      ok "پشتیبان تنظیمات SDDM حفظ شد → $SDDM_CONF_BACKUP"
+    elif sudo cp -a "$SDDM_CONF" "$SDDM_CONF_BACKUP"; then
+      ok "پشتیبان تنظیمات SDDM ساخته شد → $SDDM_CONF_BACKUP"
+    else
+      fatal "پشتیبان‌گیری از تنظیمات SDDM ناموفق بود." \
+        "برای جلوگیری از قفل‌شدن سیستم، $SDDM_CONF تغییر نکرد."
+    fi
+  fi
   step "configuring sddm → netwatch theme…"
   if [ ! -f "$SDDM_CONF" ]; then
     if sudo tee "$SDDM_CONF" >/dev/null <<'SDDMCNF'
@@ -446,42 +492,26 @@ SDDMCNF
   else
     warn "could not append a [Theme] section to $SDDM_CONF"
   fi
-  SDDM_THEME_DIR="/usr/share/sddm/themes/netwatch"
-  if sudo install -d -m 755 "$SDDM_THEME_DIR" && sudo cp -rf "$LOGINSRC/sddm-theme"/. "$SDDM_THEME_DIR"/; then
-    ok "sddm theme deployed → $SDDM_THEME_DIR"
+  if [ -e "$SDDM_CONF_BACKUP" ]; then
+    SDDM_RECOVERY="بازیابی تنظیمات قبلی: sudo cp -a $SDDM_CONF_BACKUP $SDDM_CONF"
   else
-    fatal "the netwatch sddm theme could not be deployed." \
-      "sddm.conf now points Current=netwatch at a theme dir that is not there." \
-      "Booting that combo gives you a black greeter, so this stops here." \
-      "Deploy it by hand:" \
-      "  sudo install -d -m 755 $SDDM_THEME_DIR" \
-      "  sudo cp -rf '$LOGINSRC/sddm-theme'/. $SDDM_THEME_DIR/" \
-      "Your greeter was NOT switched yet, so nothing about your login changed."
+    SDDM_RECOVERY="تنظیمات قبلی SDDM وجود نداشت؛ پیش از حذف $SDDM_CONF آن را بررسی کنید."
   fi
-  if sudo install -d -m 755 -o "$(id -un)" -g "$(id -gn)" "$SDDM_THEME_DIR/current"; then
-    if ! ls "$SDDM_THEME_DIR/current"/image.* >/dev/null 2>&1 && ! ls "$SDDM_THEME_DIR/current"/video.* >/dev/null 2>&1; then
-      SEED_WP=""
-      if [ -r "$USER_DIR/wallpaper.lua" ]; then
-        SEED_WP="$(sed -n 's/^[[:space:]]*wallpaper[[:space:]]*=[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$USER_DIR/wallpaper.lua" | tail -n 1)"
-      fi
-      [ -n "${SEED_WP:-}" ] && [ -r "$SEED_WP" ] || SEED_WP="$WALLPAPERS_PATH/netwatch/lucy.mp4"
-      SEED_EXT="${SEED_WP##*.}"
-      if [ -n "$SEED_EXT" ] && [ "$SEED_EXT" != "$SEED_WP" ] && [ -r "$SEED_WP" ]; then
-        case "$SEED_EXT" in
-          mp4|webm|mkv|mov) cp -f "$SEED_WP" "$SDDM_THEME_DIR/current/video.$SEED_EXT" ;;
-          *) cp -f "$SEED_WP" "$SDDM_THEME_DIR/current/image.$SEED_EXT" ;;
-        esac
-        chmod 644 "$SDDM_THEME_DIR/current"/image.* "$SDDM_THEME_DIR/current"/video.* 2>/dev/null
-        ok "sddm current wallpaper seeded → $SDDM_THEME_DIR/current"
-      else
-        warn "could not seed sddm current wallpaper |::| first theme load will deploy it"
-      fi
-    else
-      ok "sddm current wallpaper kept → $SDDM_THEME_DIR/current"
+  restore_sddm_state() {
+    if [ -e "$SDDM_CONF_BACKUP" ]; then
+      sudo cp -a "$SDDM_CONF_BACKUP" "$SDDM_CONF" \
+        && ok "تنظیمات قبلی SDDM بازیابی شد" \
+        || warn "بازیابی $SDDM_CONF ناموفق بود؛ از $SDDM_CONF_BACKUP استفاده کنید"
     fi
-  else
-    warn "could not create $SDDM_THEME_DIR/current |::| sddm falls back to the theme's bg.mp4"
-  fi
+    if [ "$CUR_DM" != "sddm" ]; then
+      sudo systemctl disable sddm >/dev/null 2>&1 || true
+    fi
+    if [ -n "$DM_OLD" ]; then
+      sudo systemctl enable --force "$DM_OLD.service" >/dev/null 2>&1 \
+        && ok "مدیر ورود قبلی دوباره فعال شد → $DM_OLD" \
+        || warn "فعال‌سازی دوبارهٔ $DM_OLD ناموفق بود"
+    fi
+  }
   DMLINK="$(readlink -f /etc/systemd/system/display-manager.service 2>/dev/null || true)"
   case "$DMLINK" in
     */sddm.service) ok "sddm is already the default display manager" ;;
@@ -498,14 +528,16 @@ SDDMCNF
       case "$DMLINK" in
         */sddm.service) ok "sddm enabled on boot |::| display-manager.service → sddm" ;;
         *)
+          restore_sddm_state
           fatal "sddm could not be made the default display manager." \
             "systemd said: ${SDDM_ERR:-nothing at all}" \
             "sddm.service carries Alias=display-manager.service, so plain 'enable' bails out when another greeter already owns that name." \
+            "$SDDM_RECOVERY" \
             "Do it raw:" \
             "  sudo systemctl disable ${DM_OLD:-<your-current-greeter>}.service" \
             "  sudo systemctl enable --force sddm" \
             "Then verify:  systemctl status display-manager.service" \
-            "Your existing greeter is still enabled, so you are not locked out."
+            "وضعیت بازیابی را بررسی کنید: systemctl status display-manager.service"
           ;;
       esac
       ;;
@@ -1492,7 +1524,7 @@ if [ "$ans" = "y" ] || [ "$ans" = "Y" ]; then
        *)
         err "cant confirm sddm holds the display-manager alias |::| holding the logout, choom"
          warn "eyeball it raw:  systemctl status display-manager.service"
-          [ -n "$PREV_DM" ] && [ "$PREV_DM" != "sddm" ] && sudo systemctl enable --force "$PREV_DM" >/dev/null 2>&1
+          restore_sddm_state
        exit 1
         ;;
      esac
@@ -1510,6 +1542,7 @@ if [ "$ans" = "y" ] || [ "$ans" = "Y" ]; then
             err "couldnt schedule the sddm wakeup |::| holding the logout, choom"
              warn "start it yourself from a TTY once youre out:  sudo systemctl start sddm"
               sudo systemctl stop cyber-sddm-start.timer 2>/dev/null || true
+            restore_sddm_state
             exit 1
           fi
        else
@@ -1520,7 +1553,8 @@ if [ "$ans" = "y" ] || [ "$ans" = "Y" ]; then
              ok "sddm is jacked in |::| it grabs the login screen the second you flatline your session"
             else
            err "sddm flatlined |::| jackin ${PREV_DM:-the old greeter} back in so you can delta safely"
-             [ -n "$PREV_DM" ] && [ "$PREV_DM" != "sddm" ] && sudo systemctl start "$PREV_DM.service" 2>/dev/null || true
+             restore_sddm_state
+             [ -n "$DM_OLD" ] && sudo systemctl start "$DM_OLD.service" 2>/dev/null || true
                warn "sddm corpse log:  journalctl -b -u sddm --no-pager | tail -50"
          warn "wake it yourself, choom:  sudo systemctl start sddm"
             exit 1
@@ -1528,7 +1562,8 @@ if [ "$ans" = "y" ] || [ "$ans" = "Y" ]; then
          else
         err "sddm refused the wakeup call |::| holding the logout"
            warn "journalctl -b -u sddm --no-pager | tail -50"
-            [ -n "$PREV_DM" ] && [ "$PREV_DM" != "sddm" ] && sudo systemctl start "$PREV_DM.service" 2>/dev/null || true
+            restore_sddm_state
+            [ -n "$DM_OLD" ] && sudo systemctl start "$DM_OLD.service" 2>/dev/null || true
        exit 1
         fi
       fi

--- a/tests/install/test_install_safety.sh
+++ b/tests/install/test_install_safety.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALLER="$ROOT/install.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+line_of() {
+  local pattern="$1"
+  local line
+  line="$(grep -nEm1 "$pattern" "$INSTALLER" | cut -d: -f1 || true)"
+  [ -n "$line" ] || fail "missing installer marker: $pattern"
+  printf '%s\n' "$line"
+}
+
+assert_before() {
+  local earlier="$1" later="$2" message="$3"
+  [ "$earlier" -lt "$later" ] || fail "$message"
+}
+
+bash -n "$INSTALLER"
+
+dry_run_exit="$(line_of 'DRY RUN \|::\| no changes will be made')"
+upgrade_prompt="$(line_of '^hdr "SYSTEM UPGRADE"$')"
+pacman_sync="$(line_of '^[[:space:]]*sudo pacman -Sy([[:space:]]|$)')"
+
+assert_before "$dry_run_exit" "$upgrade_prompt" \
+  "dry-run must exit before the system-upgrade prompt"
+assert_before "$dry_run_exit" "$pacman_sync" \
+  "dry-run must exit before refreshing pacman databases"
+
+# The dollar signs are intentionally literal because this searches installer source.
+# shellcheck disable=SC2016
+theme_deploy="$(line_of 'sudo cp -rf "\$LOGINSRC/sddm-theme"/\. "\$SDDM_THEME_DIR"/')"
+sddm_current="$(line_of '^Current=netwatch$')"
+sddm_backup="$(line_of '^  SDDM_CONF_BACKUP=')"
+
+assert_before "$theme_deploy" "$sddm_current" \
+  "deploy the SDDM theme before selecting it in sddm.conf"
+assert_before "$sddm_backup" "$sddm_current" \
+  "back up sddm.conf before changing the selected theme"
+
+grep -q 'sddm.conf.pre-cyberarch' "$INSTALLER" || \
+  fail "installer must print the SDDM backup path for recovery"
+
+rollback_call="$(grep -nE '^[[:space:]]*restore_sddm_state$' "$INSTALLER" | cut -d: -f1 | head -n 1 || true)"
+[ -n "$rollback_call" ] || fail "failed SDDM activation must call restore_sddm_state"
+activation_failure="$(line_of 'fatal "sddm could not be made the default display manager')"
+assert_before "$rollback_call" "$activation_failure" \
+  "restore the previous display manager before aborting"
+rollback_calls="$(grep -Ec '^[[:space:]]*restore_sddm_state$' "$INSTALLER" || true)"
+[ "$rollback_calls" -ge 5 ] || \
+  fail "every SDDM activation/start failure must restore the previous state"
+grep -qF 'if [ "$CUR_DM" != "sddm" ]; then' "$INSTALLER" || \
+  fail "rollback must disable a newly introduced SDDM service"
+
+printf 'PASS: installer safety ordering\n'

--- a/tests/qml/tst_sessionselector.qml
+++ b/tests/qml/tst_sessionselector.qml
@@ -1,0 +1,100 @@
+import QtQuick
+import QtTest
+
+Item {
+    id: testRoot
+    width: 800
+    height: 600
+
+    ListModel {
+        id: multipleSessions
+        ListElement { name: "Hyprland" }
+        ListElement { name: "Plasma (Wayland)" }
+        ListElement { name: "Plasma (X11)" }
+    }
+
+    ListModel {
+        id: singleSession
+        ListElement { name: "Hyprland" }
+    }
+
+    TestCase {
+        name: "SessionSelector"
+        when: windowShown
+
+        property var selector: null
+
+        function createSelector(sessionModel, rememberedIndex) {
+            var component = Qt.createComponent(
+                Qt.resolvedUrl("../../components/login/sddm-theme/SessionSelector.qml")
+            )
+            compare(component.status, Component.Ready, component.errorString())
+
+            selector = component.createObject(testRoot, {
+                "width": 340,
+                "model": sessionModel,
+                "rememberedIndex": rememberedIndex
+            })
+            verify(selector !== null, component.errorString())
+            tryCompare(selector, "sessionCount", sessionModel.count)
+            return selector
+        }
+
+        function cleanup() {
+            if (selector !== null) selector.destroy()
+            selector = null
+        }
+
+        function test_rememberedSessionIsSelected() {
+            var control = createSelector(multipleSessions, 1)
+
+            compare(control.currentIndex, 1)
+            compare(control.currentSessionName, "Plasma (Wayland)")
+        }
+
+        function test_invalidRememberedSessionFallsBackToFirst() {
+            var control = createSelector(multipleSessions, 99)
+
+            compare(control.currentIndex, 0)
+            compare(control.currentSessionName, "Hyprland")
+        }
+
+        function test_singleSessionCannotOpenMenu() {
+            var control = createSelector(singleSession, 0)
+
+            compare(control.interactive, false)
+            mouseClick(control, control.width / 2, control.height / 2)
+            compare(control.expanded, false)
+        }
+
+        function test_mouseCanSelectSession() {
+            var control = createSelector(multipleSessions, 0)
+
+            mouseClick(control, control.width / 2, control.height / 2)
+            compare(control.expanded, true)
+
+            tryVerify(function() { return findChild(control, "sessionOption1") !== null })
+            var option = findChild(control, "sessionOption1")
+            verify(option !== null)
+            mouseClick(option, option.width / 2, option.height / 2)
+
+            compare(control.currentIndex, 1)
+            compare(control.currentSessionName, "Plasma (Wayland)")
+            compare(control.expanded, false)
+        }
+
+        function test_keyboardCanSelectSession() {
+            var control = createSelector(multipleSessions, 0)
+
+            control.forceActiveFocus()
+            keyClick(Qt.Key_Return)
+            compare(control.expanded, true)
+            keyClick(Qt.Key_Down)
+            keyClick(Qt.Key_Return)
+
+            compare(control.currentIndex, 1)
+            compare(control.currentSessionName, "Plasma (Wayland)")
+            compare(control.expanded, false)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a Netwatch-styled SDDM session selector
- retain SDDM's remembered session as the default
- authenticate with the user-selected session index
- support keyboard and mouse selection with a safe single-session fallback
- make `install.sh --dry-run` exit before prompts or privileged mutations
- deploy the SDDM theme before selecting it and preserve `/etc/sddm.conf.pre-cyberarch`
- restore the previous SDDM configuration and display manager after activation failures
- document installation recovery and the separate Quickshell/SDDM Netwatch runtimes

## Problem

The Netwatch SDDM theme currently passes `sessionModel.lastIndex` to `sddm.login()` without exposing a way to choose another installed desktop session. On systems with CyberArch/Hyprland installed alongside KDE Plasma or another desktop, this can repeatedly launch the previously selected session.

The installer also advertised a no-change dry run after already reaching its system-upgrade prompt and `sudo pacman -Sy`. Its SDDM setup selected the theme before confirming that deployment succeeded, and failed display-manager activation paths did not consistently restore the previous manager.

## Safety

The dry run now performs only local dependency queries. SDDM activation is ordered after theme deployment and configuration backup, and each activation/start failure uses the same rollback path. No system-wide installation was performed while developing this change.

## Testing

- `QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner -input tests/qml -o -,txt` — 7 passed
- `qmllint` on the Netwatch QML components — passed
- `bash tests/install/test_install_safety.sh` — passed
- `TERM=dumb ./install.sh --dry-run` — passed without sudo or prompts
- `bash -n install.sh updater.sh tests/install/test_install_safety.sh` — passed
- `shellcheck --severity=error -e SC1087 install.sh tests/install/test_install_safety.sh` — passed
- `git diff --check` — passed
- `sddm-greeter-qt6 --test-mode --theme components/login/sddm-theme` — no QML errors
